### PR TITLE
Add Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,37 @@
 # Monitoring HQ
-This repository contains documentation and baseline setup of a Prometheus + grafana service which is intended to serve as a centralized monitoring and alerting component of the Prior Art Archive.
+This repository contains documentation and baseline setup of a Prometheus + Grafana service which is intended to serve as a centralized monitoring and alerting component of the Prior Art Archive.
 
 The repository is driven by docker and involves the following:
 
 1. An instance of [prometheus](https://prometheus.io/) which handles the collection of metrics.
-2. An instance of [grafana](https://grafana.com/) which handles the rendering of metrics.
-3. An instance of [alertmanager](https://github.com/prometheus/alertmanager) which triggers alerts based on metric outcomes.
+2. (SOON) An instance of [grafana](https://grafana.com/) which handles the rendering of metrics.
+3. (SOON) An instance of [alertmanager](https://github.com/prometheus/alertmanager) which triggers alerts based on metric outcomes.
 
 ## Setup
+We're using [Docker](https://www.docker.com/) and `docker-compose` which will let you set up your own Prometheus server to make improvements and modifications to this repository.
+
+To run the project locally:
+
+```
+docker-compose up
+```
+
+## Building and Deploying
+
+The project is run on [AWS ECS], which means in order to actually deploy you will need to [install the ecs-cli](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html).
+
+You will also need read access to the following services:
+
+1. [Our Docker organization](https://hub.docker.com/u/priorartarchive): `priorartarchive`
+2. An AWS account with permission to interact with ECS
+
+Once you've done that, this is how you would deploy a new version:
+
+```
+> docker-compose build
+> docker-compose push
+> ecs-cli compose service down --cluster prior-art-archive-monitoring
+> ecs-cli compose service up --cluster prior-art-archive-monitoring
+```
+
+Note that `prior-art-archive-monitoring` can be whatever name you have set up.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-# monitoring-hq
-The centralized component of our prometheus monitoring architecture
+# Monitoring HQ
+This repository contains documentation and baseline setup of a Prometheus + grafana service which is intended to serve as a centralized monitoring and alerting component of the Prior Art Archive.
+
+The repository is driven by docker and involves the following:
+
+1. An instance of [prometheus](https://prometheus.io/) which handles the collection of metrics.
+2. An instance of [grafana](https://grafana.com/) which handles the rendering of metrics.
+3. An instance of [alertmanager](https://github.com/prometheus/alertmanager) which triggers alerts based on metric outcomes.
+
+## Setup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.0'
+
+volumes:
+  prometheus_data: {}
+  grafana_data: {}
+
+services:
+  prometheus:
+    build: prometheus
+    image: priorartarchive/prometheus:latest
+    volumes:
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - 9090:9090

--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -1,0 +1,2 @@
+FROM prom/prometheus
+ADD prometheus.yml /etc/prometheus/prometheus.yml

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,9 @@
+# Global
+global:
+  scrape_interval:     5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+         - targets: ['localhost:9090']


### PR DESCRIPTION
This sets up Prometheus as a container in a docker-compose stack.  The stack currently only contains the one container, but I swear the added complexity of Docker-compose will be needed soon.

It also provides some basic documentation on how to run the container locally and eventually deploy to Amazon ECS.  Note that I have not yet actually set anything up on our own instance of Amazon ECS.

Prometheus is not configured beyond a vanilla self-monitoring hello world.

Resolves #1 